### PR TITLE
replace removed ProtocolConfirmation and ProtocolViolation calls

### DIFF
--- a/src/TDS.cc
+++ b/src/TDS.cc
@@ -39,7 +39,7 @@ void TDS_Analyzer::DeliverStream(int len, const u_char* data, bool orig) {
         interp->NewData(orig, data, data + len);
         }
     catch(const binpac::Exception& e) {
-        ProtocolViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
+        AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
         }
     }
 

--- a/src/tds-analyzer.pac
+++ b/src/tds-analyzer.pac
@@ -44,7 +44,7 @@ flow TDS_Flow(is_orig: bool) {
                 ${header.command} != TDS7_PRELOGIN) {
                 return false;
                 }
-            connection()->zeek_analyzer()->ProtocolConfirmation();
+            connection()->zeek_analyzer()->AnalyzerConfirmation();
             zeek::BifEvent::enqueue_tds(connection()->zeek_analyzer(),
                                         connection()->zeek_analyzer()->Conn(),
                                         is_orig(),
@@ -57,7 +57,7 @@ flow TDS_Flow(is_orig: bool) {
 
     function tds_rpc(rpc: TDS_RPC): bool %{
         if(::tds_rpc) {
-            connection()->zeek_analyzer()->ProtocolConfirmation();
+            connection()->zeek_analyzer()->AnalyzerConfirmation();
             zeek::BifEvent::enqueue_tds_rpc(connection()->zeek_analyzer(),
                                             connection()->zeek_analyzer()->Conn(),
                                             is_orig(),
@@ -75,7 +75,7 @@ flow TDS_Flow(is_orig: bool) {
                 ${sqlBatch.stream_header.header_type} != TRANSACTION_DESCRIPTOR) {
                 return false;
                 }
-            connection()->zeek_analyzer()->ProtocolConfirmation();
+            connection()->zeek_analyzer()->AnalyzerConfirmation();
             zeek::BifEvent::enqueue_tds_sql_batch(connection()->zeek_analyzer(),
                                                   connection()->zeek_analyzer()->Conn(),
                                                   is_orig(),


### PR DESCRIPTION
Replace ProtocolConfirmation and ProtocolViolation with AnalyzerConfirmation and AnalyzerViolation so the plugin works in modern Zeek installations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
