### PR TITLE
set minimum CMake requirement to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 project(Plugin)
 

--- a/configure
+++ b/configure
@@ -25,7 +25,6 @@ Usage: $0 [OPTIONS]
     --install-root=DIR         Path where to install plugin into
     --with-binpac=DIR          Path to BinPAC installation root
     --with-broker=DIR          Path to Broker installation root
-    --with-caf=DIR             Path to CAF installation root
     --with-bifcl=PATH          Path to bifcl executable
     --enable-debug             Compile in debugging mode
 EOF
@@ -85,11 +84,6 @@ while [ $# -ne 0 ]; do
         --with-broker=*)
             append_cache_entry BROKER_ROOT_DIR PATH $optarg
             broker_root=$optarg
-            ;;
-
-        --with-caf=*)
-            append_cache_entry CAF_ROOT_DIR PATH $optarg
-            caf_root=$optarg
             ;;
 
         --with-bifcl=*)
@@ -154,9 +148,6 @@ if [ -z "$zeekdist" ]; then
         append_cache_entry BROKER_ROOT_DIR PATH `${zeek_config} --broker_root`
     fi
 
-    if [ -z "$caf_root" ]; then
-        append_cache_entry CAF_ROOT_DIR PATH `${zeek_config} --caf_root`
-    fi
 else
     if [ ! -e "$zeekdist/zeek-path-dev.in" ]; then
         echo "$zeekdist does not appear to be a valid Zeek source tree."


### PR DESCRIPTION
Fixes #7.

Two changes:

* removed the deprecated `--with-caf` code that's no longer relevant to recent Zeek installations
* bumped the CMake requriement to 3.15 in order to make the plugin compatible with recent Zeek's cmake code

Installation now works in v6.0 (which is the new Zeek LTS) with this fix. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
